### PR TITLE
fix: build trigger

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,8 +1,10 @@
 name: Build image
 on:
   push:
+    branches:
+      - main
     paths:
-      - 'tailscale-versions/*'
+      - 'tailscale-versions/**'
 
 jobs:
   read_tailscale_version:


### PR DESCRIPTION
# Description

The trigger of `build` workflow sometimes does not run. Adding additional asterisk should fix it

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the DOckerfile or shell script code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?

-
